### PR TITLE
Wire shared Incutec KiCad library (submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/KiCad-Library"]
+	path = libs/KiCad-Library
+	url = https://github.com/incutec-hw/KiCad-Library.git

--- a/hardware/fp-lib-table
+++ b/hardware/fp-lib-table
@@ -1,4 +1,5 @@
 (fp_lib_table
   (version 7)
   (lib (name "4in1ESC-30x30")(type "KiCad")(uri "${KIPRJMOD}/4in1ESC-30x30.pretty")(options "")(descr ""))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/hardware/sym-lib-table
+++ b/hardware/sym-lib-table
@@ -1,4 +1,5 @@
 (sym_lib_table
   (version 7)
   (lib (name "components")(type "KiCad")(uri "${KIPRJMOD}/components.kicad_sym")(options "")(descr ""))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )


### PR DESCRIPTION
Wires the shared KiCad library into this repo:

- incutec-hw/KiCad-Library added as a submodule at libs/KiCad-Library, pinned to the feat/complete-library build (KiCad-Library#1)
- Project sym-lib-table / fp-lib-table gain the Incutec entries via ${KIPRJMOD} relative paths
- Existing local libraries untouched: they stay as the frozen record for already-routed boards

Verified: all table URIs resolve, all 195 footprints load through pcbnew from the submodule path, 105 symbols parse via kicad-cli. Clone with --recursive from now on.

After KiCad-Library#1 merges, re-pin with tools/bump-all.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)