### PR TITLE
Depersonalize public documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Open-source 4-in-1 BLDC ESC with a 30.5 × 30.5 mm mounting pattern, built aroun
 
 Part of the incutec OpenDrone line (`incutec-hw/OpenESC-30x30`).
 
-> A smaller **[OpenESC_20X20](https://github.com/incutec-hw/OpenESC_20X20)** (20×20 mm) shares this design and mirrors this repo. The two differ only in board/mounting size and a few power-stage parts.
+> A smaller **[OpenESC-20x20](https://github.com/incutec-hw/OpenESC-20x20)** (20×20 mm) shares this design and mirrors this repo. The two differ only in board/mounting size and a few power-stage parts.
 
 ## Architecture
 
@@ -39,7 +39,7 @@ Four fully independent ESC channels share a common power input and telemetry con
 | PCB | 6-layer, 1.69 mm |
 | Mounting pattern | 30.5 × 30.5 mm, 4× Ø4.0 mm holes (M3) |
 
-Current/voltage ratings are not printed on the design files. The input clamp is set by the SMBJ24A TVS (24 V standoff → 3S–6S); the MOSFET (SP40N01GHNK) and current-sense full-scale (~330 A) set the practical envelope. Characterize before quoting a hard rating.
+Current and voltage ratings have not been characterized. The input clamp is set by the SMBJ24A TVS (24 V standoff → 3S–6S); the MOSFET (SP40N01GHNK) and current-sense full-scale (~330 A) set the practical envelope.
 
 ## Connector
 
@@ -65,7 +65,7 @@ Connector ground returns on the shield/mounting pads P1/P2 (both GND). The same 
 | `hardware/4in1.kicad_pro` / `.kicad_pcb` / `.kicad_sch` | Main design (30×30). |
 | `hardware/4in1-panel.kicad_pro` / `.kicad_pcb` | Panelized version for production fabrication. |
 
-This repo is the 30×30 member of the OpenESC family; the 20×20 sibling lives in [`OpenESC_20X20`](https://github.com/incutec-hw/OpenESC_20X20). Production exports in `hardware/production/` are versioned `V0.1`–`V0.4` and `Rev1`. `Rev1-30x30` is the 30×30-only fabrication set; `Rev1-30x3020x20` is a combined shared-fab set produced alongside the mini.
+This repo is the 30×30 member of the OpenESC family; the 20×20 sibling lives in [`OpenESC-20x20`](https://github.com/incutec-hw/OpenESC-20x20). Production exports in `hardware/production/` are versioned `V0.1`–`V0.4` and `Rev1`. `Rev1-30x30` is the 30×30-only fabrication set; `Rev1-30x3020x20` is a combined shared-fab set produced alongside the mini.
 
 ## Firmware
 

--- a/hardware/database/cap_analysis.md
+++ b/hardware/database/cap_analysis.md
@@ -12,7 +12,7 @@ Samsung published data from their product tool (measured at 1kHz, 25°C):
 - **X5R 10µF 50V 1206**: -87% → ~1.3µF effective
 - **X7R 10µF 50V 1206**: -78% → ~2.2µF effective
 
-Murata X7T performs similarly per Stan's assessment — expect ~2–3µF effective at 25V.
+Murata X7T performs similarly: expect ~2–3µF effective at 25V.
 Bottom line: **all 10µF 50V 1206 MLCCs give only ~2–3µF at operating voltage.**
 
 ## Candidate Parts — 10µF 50V 1206


### PR DESCRIPTION
Removes person-directed phrasing and fixes stale links:

- hardware/database/cap_analysis.md: "per Stan's assessment — expect" is now "performs similarly: expect", impersonal and without the em dash.
- README.md: the note-to-self "Characterize before quoting a hard rating." is now neutral documentation: "Current and voltage ratings have not been characterized." with the envelope sentence retained.
- README.md: both OpenESC_20X20 links (intro note and Production section) updated to the renamed OpenESC-20x20 repo slug and label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)