### PR TITLE
Fix verification findings: style, slugs, depersonalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Newest first. Dates are fabrication export dates.
 
-- **Rev1** (2026-06-05): validated build. Fabrication sets `Rev1-30x30` (30x30 only) and `Rev1-30x3020x20` (combined with OpenESC_20X20).
+- **Rev1** (2026-06-05): validated build. Fabrication sets `Rev1-30x30` (30x30 only) and `Rev1-30x3020x20` (combined with OpenESC-20x20).
 - **V0.4** (2026-05-29): combined export `V0.4-20x20-30x30`.
 - **V0.3** (2026-05-06): export `V0.3`; combined `V0.3-20x20-30x30` followed on 2026-05-12.
 - **V0.2** (2026-05-05): export `V0.2`.

--- a/hardware/docs/DESIGN.md
+++ b/hardware/docs/DESIGN.md
@@ -60,7 +60,7 @@ Connector ground returns on the shield/mounting pads P1/P2 (both GND). The same 
 | `hardware/4in1.kicad_pro` / `.kicad_pcb` / `.kicad_sch` | Main design (30x30) |
 | `hardware/4in1-panel.kicad_pro` / `.kicad_pcb` | Panelized version for production fabrication |
 
-This repo is the 30x30 member of the OpenESC family. A smaller sibling, [OpenESC_20X20](https://github.com/incutec-hw/OpenESC_20X20) (20x20 mm), shares this design and mirrors this repo; the two differ only in board/mounting size and a few power-stage parts. Fabrication sets are generated per revision into `hardware/production/` (gitignored) with the Fabrication Toolkit; the revision history is in [CHANGELOG.md](../../CHANGELOG.md).
+This repo is the 30x30 member of the OpenESC family. A smaller sibling, [OpenESC-20x20](https://github.com/incutec-hw/OpenESC-20x20) (20x20 mm), shares this design and mirrors this repo; the two differ only in board/mounting size and a few power-stage parts. Fabrication sets are generated per revision into `hardware/production/` (gitignored) with the Fabrication Toolkit; the revision history is in [CHANGELOG.md](../../CHANGELOG.md).
 
 ## Firmware
 


### PR DESCRIPTION
Clean-room verification fixes for docs prose.

- CHANGELOG.md: old slug OpenESC_20X20 renamed to OpenESC-20x20
- hardware/docs/DESIGN.md: link text and URL updated from OpenESC_20X20 to OpenESC-20x20 (avoids GitHub redirect)

Skipped (handled in a separate pass, .kicad_* files are not edited here):
- hardware/4in1.kicad_pro line 702: em dash in DOC_TAGLINE
- hardware/4in1.kicad_pro lines 706-707: en dashes in DOC_INPUT / DOC_RATING

🤖 Generated with [Claude Code](https://claude.com/claude-code)