### PR TITLE
Local libraries are the working default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,15 @@ kicad-cli pcb drc --exit-code-violations hardware/4in1-panel.kicad_pcb
 
 ## Parts
 
-New symbols, footprints and 3D models go to
-[incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) by pull
-request there, never into this repo. Prefer LCSC basic parts.
+Add new symbols, footprints and 3D models to this repo's local libraries.
+That is the working default.
+
+[incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) is a
+mirror of parts we already use or stock. Check it first: if the part is there,
+we have used it before, which saves sourcing work. Promoting a part into it is
+a separate deliberate step, not a requirement for contributing here.
+
+Prefer LCSC basic parts.
 
 ## Licensing
 


### PR DESCRIPTION
Reflects the current policy: new parts go into local libs, KiCad-Library is a stocked-parts mirror to check first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)