### PR TITLE
README: status badge from the site endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ standard 8-pin connector.
 <img src="images/back.png" width="400" alt="OpenESC-30x30 bottom" />
 </p>
 
-[![Status](https://img.shields.io/badge/status-alpha-e08c00)](https://github.com/OpenDrone-hw/.github/blob/main/CONTRIBUTING.md#the-life-of-a-project)
+[![Status](https://img.shields.io/endpoint?url=https://opendrone.be/api/status/OpenESC-30x30.json)](https://github.com/OpenDrone-hw/.github/blob/main/CONTRIBUTING.md#the-life-of-a-project)
 [![Shop](https://img.shields.io/badge/shop-opendrone.be-ffb700)](https://opendrone.be/products/openesc)
 [![Discord](https://img.shields.io/badge/Discord-%23esc-5865F2?logo=discord&logoColor=white)](https://discord.com/channels/1494019459822653512/1494782966302507118)
 [![Video](https://img.shields.io/badge/YouTube-How%20Drone%20ESCs%20Work-FF0000?logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=TwAmmPxOpTM)


### PR DESCRIPTION
The status badge now renders from opendrone.be/api/status/OpenESC-30x30.json, the same status-* topic fetch the roadmap and shop resolve, so the README can never state a status the repo does not carry. Org-wide change; contract in the org CONTRIBUTING (OpenDrone-hw/.github#7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)